### PR TITLE
hiding post revisions from autocomplete

### DIFF
--- a/admin/class-largo-related-posts-admin.php
+++ b/admin/class-largo-related-posts-admin.php
@@ -170,7 +170,7 @@ class Largo_Related_Posts_Admin {
 		$search = like_escape($_REQUEST['term']);
 
 		$query = 'SELECT post_title, ID FROM wp_posts
-		WHERE post_title LIKE \'%' . $search . '%\'';
+		WHERE post_title LIKE \'%' . $search . '%\' AND `post_status` != \'inherit\'';
 
 		$suggestions = array();
 


### PR DESCRIPTION
fixes #9 
## Problem

Revisions are showing up in the autocomplete box on the post edit screen for related posts.

## Solution

modify the query to explicitly exclude the `inherit` post_status, which is used for sub-post types including revisions and media.