### PR TITLE
use a cache group here instead of a single cache key

### DIFF
--- a/admin/class-largo-related-posts-admin.php
+++ b/admin/class-largo-related-posts-admin.php
@@ -199,10 +199,10 @@ class Largo_Related_Posts_Admin {
 			$search
 		);
 
-		$result = wp_cache_get( 'largo_related_posts_query' );
+		$result = wp_cache_get( sanitize_key( $_REQUEST[ 'term' ] ), 'largo_related_posts_query' );
 		if ( false === $result ) {
 			$result = $wpdb->get_results( $sql );
-			wp_cache_set( 'largo_related_posts_query', $result );
+			wp_cache_set( sanitize_key( $_REQUEST[ 'term' ] ), $result, 'largo_related_posts_query', DAY_IN_SECONDS );
 		}
 
 		$suggestions = array();


### PR DESCRIPTION
this works better in most cases because, depending on the server configuration, using a single cache key instead of a group could cause the first search query to become persistent for the session, this caches each individual request and keeps it around for a day